### PR TITLE
feat: add explicit /on and /off endpoints for devices

### DIFF
--- a/Homie/App/HomieApp.swift
+++ b/Homie/App/HomieApp.swift
@@ -314,6 +314,8 @@ struct ContentView: View {
                 endpointRow("GET", "/device/{name}", "Get device state", nil)
                 endpointRow("GET", "/device/{name}/schema", "JSON schema", nil)
                 endpointRow("POST", "/device/{name}/toggle", "Toggle on/off", nil)
+                endpointRow("POST", "/device/{name}/on", "Turn on", nil)
+                endpointRow("POST", "/device/{name}/off", "Turn off", nil)
                 endpointRow("POST", "/device/{name}/set", "Set state", #"{"on": bool, "brightness": 0-100}"#)
                 endpointRow("GET", "/rooms", "List all rooms", nil)
                 endpointRow("GET", "/room/{name}", "Devices in room", nil)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ curl localhost:8420/device/Desk_Lamp
 # Toggle
 curl -X POST localhost:8420/device/Desk_Lamp/toggle
 
+# Explicit on/off
+curl -X POST localhost:8420/device/Desk_Lamp/on
+curl -X POST localhost:8420/device/Desk_Lamp/off
+
 # Set brightness
 curl -X POST localhost:8420/device/Desk_Lamp/set \
   -H "Content-Type: application/json" \
@@ -109,6 +113,10 @@ curl localhost:8420/room/Office
 # Room on/off
 curl -X POST localhost:8420/room/Office/on
 curl -X POST localhost:8420/room/Office/off
+
+# Room-scoped device on/off
+curl -X POST localhost:8420/room/Office/device/Desk_Lamp/on
+curl -X POST localhost:8420/room/Office/device/Desk_Lamp/off
 ```
 
 ### Scenes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,7 +122,11 @@ GET  /health              # Health check
 GET  /devices             # List all devices
 GET  /device/:id          # Get device state
 POST /device/:id/toggle   # Toggle device
+POST /device/:id/on       # Turn device on
+POST /device/:id/off      # Turn device off
 POST /device/:id/set      # Set state {on, brightness}
+POST /room/:r/device/:d/on   # Turn room-scoped device on
+POST /room/:r/device/:d/off  # Turn room-scoped device off
 GET  /scenes              # List scenes
 POST /scene/:id/trigger   # Trigger scene
 GET  /rules               # List app-aware rules


### PR DESCRIPTION
Fixes #3

Added explicit endpoints for setting device state:
- `POST /device/{name}/on`
- `POST /device/{name}/off`
- `POST /room/{name}/device/{name}/on`
- `POST /room/{name}/device/{name}/off`

**Tests:** 10 passed (api_test.sh)