### PR TITLE
fix: correct Package.swift CLI target path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,12 @@ let package = Package(
         .macOS(.v13)
     ],
     products: [
-        .executable(name: "hkctl", targets: ["hkctl"])
+        .executable(name: "lilhomie", targets: ["lilhomie"])
     ],
     targets: [
         .executableTarget(
-            name: "hkctl",
-            path: "hkctl"
+            name: "lilhomie",
+            path: "lilhomie-cli"
         )
     ]
 )


### PR DESCRIPTION
Fixes #7

Updated Package.swift to reference the correct CLI directory:
- Changed target name from `hkctl` to `lilhomie`
- Changed path from `hkctl` to `lilhomie-cli`

`swift build` now passes.