### PR TITLE
feat: add --json output flag and shell completions (bash/zsh/fish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ up completions for your shell:
 sudo cp completions/lilhomie.zsh /usr/local/share/zsh/site-functions/_lilhomie
 
 # Option B — add completions dir to fpath in ~/.zshrc
-echo 'fpath=(/usr/local/share/lilhomie/completions $fpath)' >> ~/.zshrc
+mkdir -p ~/.config/lilhomie/completions
+cp completions/lilhomie.zsh ~/.config/lilhomie/completions/
+echo 'fpath=(~/.config/lilhomie/completions $fpath)' >> ~/.zshrc
 echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
 
 # Option C — Oh-My-Zsh
@@ -98,13 +100,19 @@ cp completions/lilhomie.zsh ~/.oh-my-zsh/completions/_lilhomie
 sudo cp completions/lilhomie.bash /etc/bash_completion.d/lilhomie
 
 # Option B — source directly from ~/.bashrc
-echo 'source /usr/local/share/lilhomie/completions/lilhomie.bash' >> ~/.bashrc
+mkdir -p ~/.config/lilhomie/completions
+cp completions/lilhomie.bash ~/.config/lilhomie/completions/
+echo 'source ~/.config/lilhomie/completions/lilhomie.bash' >> ~/.bashrc
 ```
 
 #### fish
 
 ```bash
+# User completions directory (no sudo required)
 cp completions/lilhomie.fish ~/.config/fish/completions/lilhomie.fish
+
+# Or system-wide
+sudo cp completions/lilhomie.fish /usr/share/fish/vendor_completions.d/lilhomie.fish
 ```
 
 Then restart your shell (or run `exec $SHELL`) and tab-completion for

--- a/completions/lilhomie.bash
+++ b/completions/lilhomie.bash
@@ -1,6 +1,6 @@
 # bash completion for lilhomie
 # Install: source this file in your ~/.bashrc or ~/.bash_profile
-#   echo 'source /usr/local/share/lilhomie/completions/lilhomie.bash' >> ~/.bashrc
+#   echo 'source ~/.config/lilhomie/completions/lilhomie.bash' >> ~/.bashrc
 #
 # Or copy to the bash_completion.d directory:
 #   sudo cp lilhomie.bash /etc/bash_completion.d/lilhomie
@@ -15,24 +15,55 @@ _lilhomie_completions() {
     local commands="list ls devices scenes status get toggle on off set scene info status-all help"
     local global_flags="--json -j --help -h"
 
-    # First argument: complete subcommands
+    # First argument: complete subcommands and global flags
     if [[ "${COMP_CWORD}" -eq 1 ]]; then
         COMPREPLY=( $(compgen -W "${commands} ${global_flags}" -- "${cur}") )
         return 0
     fi
 
-    local cmd="${COMP_WORDS[1]}"
+    # Find the subcommand (first non-flag word after 'lilhomie')
+    local cmd=""
+    local i
+    for (( i=1; i < COMP_CWORD; i++ )); do
+        local word="${COMP_WORDS[i]}"
+        case "${word}" in
+            --json|-j|--help|-h) continue ;;
+            *) cmd="${word}"; break ;;
+        esac
+    done
 
     # After a subcommand, offer --json / -j (and -h / --help)
     case "${cmd}" in
         list|ls|devices|scenes|info|status-all)
             COMPREPLY=( $(compgen -W "--json -j --help -h" -- "${cur}") )
             ;;
-        status|get|toggle|on|off|set|scene)
-            # Offer flag completions alongside any in-progress text
+        status|get|toggle|on|off|scene)
+            # Device/scene name argument — offer flags if current word starts with '-'
             if [[ "${cur}" == -* ]]; then
                 COMPREPLY=( $(compgen -W "--json -j --help -h" -- "${cur}") )
             fi
+            # Multi-word device names are handled by the user quoting the argument;
+            # no static list to complete against without querying the live API.
+            ;;
+        set)
+            # Last positional is the brightness level; second-to-last is device name.
+            # Offer brightness values once the device name token is already present.
+            if [[ "${cur}" == -* ]]; then
+                COMPREPLY=( $(compgen -W "--json -j --help -h" -- "${cur}") )
+            else
+                # Count non-flag words after the subcommand
+                local positionals=0
+                for (( i=2; i < COMP_CWORD; i++ )); do
+                    [[ "${COMP_WORDS[i]}" == -* ]] || (( positionals++ ))
+                done
+                if (( positionals >= 1 )); then
+                    # At least device name present — complete brightness
+                    COMPREPLY=( $(compgen -W "0 10 20 25 30 40 50 60 70 75 80 90 100" -- "${cur}") )
+                fi
+            fi
+            ;;
+        *)
+            COMPREPLY=( $(compgen -W "${commands} ${global_flags}" -- "${cur}") )
             ;;
     esac
 

--- a/completions/lilhomie.fish
+++ b/completions/lilhomie.fish
@@ -3,8 +3,8 @@
 # Install:
 #   cp lilhomie.fish ~/.config/fish/completions/lilhomie.fish
 #
-# Or if you have a custom completions directory:
-#   cp lilhomie.fish /usr/local/share/fish/vendor_completions.d/lilhomie.fish
+# Or system-wide:
+#   sudo cp lilhomie.fish /usr/share/fish/vendor_completions.d/lilhomie.fish
 
 # Disable file completions globally for lilhomie
 complete -c lilhomie -f
@@ -16,29 +16,12 @@ complete -c lilhomie -l json  -s j -d 'Output raw JSON (pipe into jq, etc)'
 complete -c lilhomie -l help  -s h -d 'Show help message'
 
 # ---------------------------------------------------------------------------
-# Subcommands
-# ---------------------------------------------------------------------------
-complete -c lilhomie -n '__fish_use_subcommand' -a list       -d 'List all HomeKit devices grouped by room'
-complete -c lilhomie -n '__fish_use_subcommand' -a ls         -d 'Alias for list'
-complete -c lilhomie -n '__fish_use_subcommand' -a devices    -d 'Alias for list'
-complete -c lilhomie -n '__fish_use_subcommand' -a scenes     -d 'List all HomeKit scenes'
-complete -c lilhomie -n '__fish_use_subcommand' -a status     -d 'Get status of a device'
-complete -c lilhomie -n '__fish_use_subcommand' -a get        -d 'Alias for status'
-complete -c lilhomie -n '__fish_use_subcommand' -a toggle     -d 'Toggle a device on/off'
-complete -c lilhomie -n '__fish_use_subcommand' -a on         -d 'Turn a device on'
-complete -c lilhomie -n '__fish_use_subcommand' -a off        -d 'Turn a device off'
-complete -c lilhomie -n '__fish_use_subcommand' -a set        -d 'Set device brightness (0-100)'
-complete -c lilhomie -n '__fish_use_subcommand' -a scene      -d 'Trigger a scene'
-complete -c lilhomie -n '__fish_use_subcommand' -a info       -d 'Show Homie app status'
-complete -c lilhomie -n '__fish_use_subcommand' -a status-all -d 'Alias for info'
-complete -c lilhomie -n '__fish_use_subcommand' -a help       -d 'Show help message'
-
-# ---------------------------------------------------------------------------
-# Helper: detect which subcommand is active
+# Helper: return the active subcommand, if any
 # ---------------------------------------------------------------------------
 function __lilhomie_subcommand
     set -l cmd (commandline -opc)
     set -l subcmds list ls devices scenes status get toggle on off set scene info status-all help
+    # Skip the program name (index 1) and check remaining tokens
     for word in $cmd[2..]
         if contains -- $word $subcmds
             echo $word
@@ -48,17 +31,38 @@ function __lilhomie_subcommand
     return 1
 end
 
+function __fish_lilhomie_no_subcommand
+    not __lilhomie_subcommand > /dev/null 2>&1
+end
+
 function __fish_lilhomie_using_subcommand
     set -l sub (__lilhomie_subcommand)
     contains -- $sub $argv
 end
 
 # ---------------------------------------------------------------------------
-# Subcommand-specific flag completions
-# (--json / -j already added globally above; add any subcommand-only flags here)
+# Subcommands (only shown before any subcommand is given)
+# ---------------------------------------------------------------------------
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a list       -d 'List all HomeKit devices grouped by room'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a ls         -d 'Alias for list'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a devices    -d 'Alias for list'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a scenes     -d 'List all HomeKit scenes'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a status     -d 'Get status of a device'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a get        -d 'Alias for status'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a toggle     -d 'Toggle a device on/off'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a on         -d 'Turn a device on'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a off        -d 'Turn a device off'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a set        -d 'Set device brightness (0-100)'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a scene      -d 'Trigger a scene'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a info       -d 'Show Homie app status'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a status-all -d 'Alias for info'
+complete -c lilhomie -n '__fish_lilhomie_no_subcommand' -a help       -d 'Show help message'
+
+# ---------------------------------------------------------------------------
+# Subcommand-specific completions
 # ---------------------------------------------------------------------------
 
-# set: brightness argument hint
+# set: brightness argument hint (after subcommand is detected)
 complete -c lilhomie -n '__fish_lilhomie_using_subcommand set' \
     -a '0 10 20 25 30 40 50 60 70 75 80 90 100' \
     -d 'Brightness level'

--- a/completions/lilhomie.zsh
+++ b/completions/lilhomie.zsh
@@ -7,7 +7,7 @@
 #   sudo cp lilhomie.zsh /usr/local/share/zsh/site-functions/_lilhomie
 #
 # Option B — add the completions directory to $fpath in ~/.zshrc:
-#   fpath=(/usr/local/share/lilhomie/completions $fpath)
+#   fpath=(~/.config/lilhomie/completions $fpath)
 #   autoload -Uz compinit && compinit
 #
 # Option C — Oh-My-Zsh:
@@ -40,25 +40,29 @@ _lilhomie() {
         'help:Show help message'
     )
 
-    # Complete the first positional argument (subcommand)
+    # Complete the first positional argument (subcommand or global flag)
     if (( CURRENT == 2 )); then
-        _describe 'command' commands
         _arguments $global_flags
+        _describe 'command' commands
         return
     fi
 
+    # Find the subcommand — skip leading flags
+    local cmd
+    local -i i
+    for (( i = 2; i <= CURRENT; i++ )); do
+        case "${words[i]}" in
+            --json|-j|--help|-h) continue ;;
+            *) cmd="${words[i]}"; break ;;
+        esac
+    done
+
     # Complete flags and arguments for each subcommand
-    local cmd="${words[2]}"
     case "${cmd}" in
         list|ls|devices|scenes|info|status-all|help)
             _arguments $global_flags
             ;;
-        status|get)
-            _arguments \
-                $global_flags \
-                ':device name: '
-            ;;
-        toggle|on|off)
+        status|get|toggle|on|off)
             _arguments \
                 $global_flags \
                 ':device name: '
@@ -67,7 +71,7 @@ _lilhomie() {
             _arguments \
                 $global_flags \
                 ':device name: ' \
-                ':brightness (0-100): '
+                ':brightness (0-100):(0 10 20 25 30 40 50 60 70 75 80 90 100)'
             ;;
         scene)
             _arguments \
@@ -76,6 +80,7 @@ _lilhomie() {
             ;;
         *)
             _arguments $global_flags
+            _describe 'command' commands
             ;;
     esac
 }

--- a/lilhomie-cli/main.swift
+++ b/lilhomie-cli/main.swift
@@ -56,19 +56,19 @@ func parseGlobalFlags(_ rawArgs: [String]) -> (args: [String], jsonOutput: Bool)
 func request(_ method: String, _ path: String, body: [String: Any]? = nil) -> Data? {
     guard let url = URL(string: baseURL + path) else { return nil }
     
-    var request = URLRequest(url: url)
-    request.httpMethod = method
-    request.timeoutInterval = 10
+    var req = URLRequest(url: url)
+    req.httpMethod = method
+    req.timeoutInterval = 10
     
     if let body = body {
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
     }
     
     let semaphore = DispatchSemaphore(value: 0)
     var result: Data?
     
-    URLSession.shared.dataTask(with: request) { data, _, error in
+    URLSession.shared.dataTask(with: req) { data, _, error in
         result = error == nil ? data : nil
         semaphore.signal()
     }.resume()
@@ -84,209 +84,177 @@ func printJSON(_ data: Data) {
        let str = String(data: pretty, encoding: .utf8) {
         print(str)
     } else if let str = String(data: data, encoding: .utf8) {
-        // Fall back to raw bytes if we can't pretty-print
         print(str)
     } else {
         print("{}")
     }
 }
 
+// MARK: - Shared Fetch Helper
+
+/// Fetch data from the API and either emit raw JSON (when `jsonOutput` is true) or
+/// decode the response to `T` and hand it to `display`.  Exits on network/decode failure.
+func fetchAndDisplay<T: Decodable>(
+    method: String,
+    path: String,
+    body: [String: Any]? = nil,
+    jsonOutput: Bool,
+    failMessage: String,
+    as type: T.Type,
+    display: (T) -> Void
+) {
+    guard let data = request(method, path, body: body) else {
+        print(failMessage)
+        exit(1)
+    }
+    if jsonOutput {
+        printJSON(data)
+        return
+    }
+    guard let decoded = try? JSONDecoder().decode(type, from: data) else {
+        print(failMessage)
+        exit(1)
+    }
+    display(decoded)
+}
+
 // MARK: - Commands
 
 func listDevices(jsonOutput: Bool = false) {
-    guard let data = request("GET", "/devices") else {
-        print("❌ Failed to connect to Homie. Is the app running?")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(DevicesResponse.self, from: data) else {
-        print("❌ Failed to parse devices response")
-        exit(1)
-    }
-    
-    if response.devices.isEmpty {
-        print("No devices found.")
-        return
-    }
-    
-    print("📱 HomeKit Devices:\n")
-    
-    // Group by room
-    let grouped = Dictionary(grouping: response.devices) { $0.room ?? "No Room" }
-    for (room, devices) in grouped.sorted(by: { $0.key < $1.key }) {
-        print("  \(room):")
-        for device in devices.sorted(by: { $0.name < $1.name }) {
-            let status = device.isOn ? "🟢" : "⚪️"
-            let brightness = device.brightness.map { " (\($0)%)" } ?? ""
-            print("    \(status) \(device.name)\(brightness)")
+    fetchAndDisplay(
+        method: "GET", path: "/devices",
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to connect to Homie. Is the app running?",
+        as: DevicesResponse.self
+    ) { response in
+        if response.devices.isEmpty {
+            print("No devices found.")
+            return
         }
-        print("")
+        print("📱 HomeKit Devices:\n")
+        let grouped = Dictionary(grouping: response.devices) { $0.room ?? "No Room" }
+        for (room, devices) in grouped.sorted(by: { $0.key < $1.key }) {
+            print("  \(room):")
+            for device in devices.sorted(by: { $0.name < $1.name }) {
+                let status = device.isOn ? "🟢" : "⚪️"
+                let brightness = device.brightness.map { " (\($0)%)" } ?? ""
+                print("    \(status) \(device.name)\(brightness)")
+            }
+            print("")
+        }
+        print("Total: \(response.devices.count) devices")
     }
-    
-    print("Total: \(response.devices.count) devices")
 }
 
 func listScenes(jsonOutput: Bool = false) {
-    guard let data = request("GET", "/scenes") else {
-        print("❌ Failed to connect to Homie. Is the app running?")
-        exit(1)
+    fetchAndDisplay(
+        method: "GET", path: "/scenes",
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to connect to Homie. Is the app running?",
+        as: ScenesResponse.self
+    ) { response in
+        if response.scenes.isEmpty {
+            print("No scenes found.")
+            return
+        }
+        print("🎬 HomeKit Scenes:\n")
+        for scene in response.scenes {
+            print("  • \(scene.name) (\(scene.actions) actions)")
+        }
+        print("\nTotal: \(response.scenes.count) scenes")
     }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(ScenesResponse.self, from: data) else {
-        print("❌ Failed to parse scenes response")
-        exit(1)
-    }
-    
-    if response.scenes.isEmpty {
-        print("No scenes found.")
-        return
-    }
-    
-    print("🎬 HomeKit Scenes:\n")
-    for scene in response.scenes {
-        print("  • \(scene.name) (\(scene.actions) actions)")
-    }
-    print("\nTotal: \(response.scenes.count) scenes")
 }
 
 func getStatus(_ name: String, jsonOutput: Bool = false) {
     let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
-    guard let data = request("GET", "/device/\(encoded)") else {
-        print("❌ Device '\(name)' not found")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let device = try? JSONDecoder().decode(Device.self, from: data) else {
-        print("❌ Device '\(name)' not found")
-        exit(1)
-    }
-    
-    print("📱 \(device.name)")
-    print("   Status: \(device.isOn ? "🟢 ON" : "⚪️ OFF")")
-    if let brightness = device.brightness {
-        print("   Brightness: \(brightness)%")
-    }
-    if let room = device.room {
-        print("   Room: \(room)")
+    fetchAndDisplay(
+        method: "GET", path: "/device/\(encoded)",
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Device '\(name)' not found",
+        as: Device.self
+    ) { device in
+        print("📱 \(device.name)")
+        print("   Status: \(device.isOn ? "🟢 ON" : "⚪️ OFF")")
+        if let brightness = device.brightness {
+            print("   Brightness: \(brightness)%")
+        }
+        if let room = device.room {
+            print("   Room: \(room)")
+        }
     }
 }
 
 func toggleDevice(_ name: String, jsonOutput: Bool = false) {
     let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
-    guard let data = request("POST", "/device/\(encoded)/toggle") else {
-        print("❌ Failed to toggle '\(name)'")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(ActionResponse.self, from: data) else {
-        print("❌ Failed to toggle '\(name)'")
-        exit(1)
-    }
-    
-    if response.success == true {
-        if let device = response.device {
-            print("✅ \(device.name) → \(device.isOn ? "ON 🟢" : "OFF ⚪️")")
+    fetchAndDisplay(
+        method: "POST", path: "/device/\(encoded)/toggle",
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to toggle '\(name)'",
+        as: ActionResponse.self
+    ) { response in
+        if response.success == true {
+            if let device = response.device {
+                print("✅ \(device.name) → \(device.isOn ? "ON 🟢" : "OFF ⚪️")")
+            } else {
+                print("✅ Toggled '\(name)'")
+            }
         } else {
-            print("✅ Toggled '\(name)'")
+            print("❌ \(response.error ?? "Unknown error")")
+            exit(1)
         }
-    } else {
-        print("❌ \(response.error ?? "Unknown error")")
-        exit(1)
     }
 }
 
 func setDevice(_ name: String, on: Bool, jsonOutput: Bool = false) {
     let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
-    guard let data = request("POST", "/device/\(encoded)/set", body: ["on": on]) else {
-        print("❌ Failed to set '\(name)'")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(ActionResponse.self, from: data) else {
-        print("❌ Failed to set '\(name)'")
-        exit(1)
-    }
-    
-    if response.success == true {
-        print("✅ \(name) → \(on ? "ON 🟢" : "OFF ⚪️")")
-    } else {
-        print("❌ \(response.error ?? "Unknown error")")
-        exit(1)
+    fetchAndDisplay(
+        method: "POST", path: "/device/\(encoded)/set",
+        body: ["on": on],
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to set '\(name)'",
+        as: ActionResponse.self
+    ) { response in
+        if response.success == true {
+            print("✅ \(name) → \(on ? "ON 🟢" : "OFF ⚪️")")
+        } else {
+            print("❌ \(response.error ?? "Unknown error")")
+            exit(1)
+        }
     }
 }
 
 func setBrightness(_ name: String, _ level: Int, jsonOutput: Bool = false) {
     let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
-    guard let data = request("POST", "/device/\(encoded)/set", body: ["on": true, "brightness": level]) else {
-        print("❌ Failed to set brightness for '\(name)'")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(ActionResponse.self, from: data) else {
-        print("❌ Failed to set brightness for '\(name)'")
-        exit(1)
-    }
-    
-    if response.success == true {
-        print("✅ \(name) → \(level)%")
-    } else {
-        print("❌ \(response.error ?? "Unknown error")")
-        exit(1)
+    fetchAndDisplay(
+        method: "POST", path: "/device/\(encoded)/set",
+        body: ["on": true, "brightness": level],
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to set brightness for '\(name)'",
+        as: ActionResponse.self
+    ) { response in
+        if response.success == true {
+            print("✅ \(name) → \(level)%")
+        } else {
+            print("❌ \(response.error ?? "Unknown error")")
+            exit(1)
+        }
     }
 }
 
 func triggerScene(_ name: String, jsonOutput: Bool = false) {
     let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
-    guard let data = request("POST", "/scene/\(encoded)/trigger") else {
-        print("❌ Failed to trigger scene '\(name)'")
-        exit(1)
-    }
-
-    if jsonOutput {
-        printJSON(data)
-        return
-    }
-
-    guard let response = try? JSONDecoder().decode(ActionResponse.self, from: data) else {
-        print("❌ Failed to trigger scene '\(name)'")
-        exit(1)
-    }
-    
-    if response.success == true {
-        print("✅ Scene '\(name)' triggered")
-    } else {
-        print("❌ \(response.error ?? "Scene not found")")
-        exit(1)
+    fetchAndDisplay(
+        method: "POST", path: "/scene/\(encoded)/trigger",
+        jsonOutput: jsonOutput,
+        failMessage: "❌ Failed to trigger scene '\(name)'",
+        as: ActionResponse.self
+    ) { response in
+        if response.success == true {
+            print("✅ Scene '\(name)' triggered")
+        } else {
+            print("❌ \(response.error ?? "Scene not found")")
+            exit(1)
+        }
     }
 }
 
@@ -295,12 +263,10 @@ func showStatus(jsonOutput: Bool = false) {
         print("❌ Failed to connect to Homie. Is the app running?")
         exit(1)
     }
-
     if jsonOutput {
         printJSON(data)
         return
     }
-
     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         print("❌ Failed to connect to Homie. Is the app running?")
         exit(1)


### PR DESCRIPTION
## Summary

Two quality-of-life improvements for the `lilhomie` CLI.

---

## Task 1 — `--json` / `-j` output flag

Added a global `--json` (alias `-j`) flag to every command. When set, the CLI skips human-readable formatting and pretty-prints the raw JSON response from the Homie API. This makes the CLI much more useful for scripting and piping into tools like `jq`.

### How it works

```
parseGlobalFlags()  →  strips --json/-j before the switch statement
                        so the flag works anywhere in the argument list
```

Every command function gained a `jsonOutput: Bool` parameter. When `true`, it prints pretty JSON and returns early.

### Examples

```bash
# Raw device list — pipe into jq
lilhomie list --json
lilhomie list --json | jq '.devices[] | select(.isOn) | .name'

# Single device JSON
lilhomie status "Desk Lamp" --json

# Scenes JSON
lilhomie scenes -j | jq '.scenes[].name'

# Scripting
IS_ON=$(lilhomie status "Desk Lamp" --json | jq -r '.isOn')
```

---

## Task 2 — Shell completions

Three completion scripts added to `completions/`:

| File | Shell | Covers |
|------|-------|--------|
| `completions/lilhomie.bash` | bash | subcommands, `--json`/`-j`/`--help`/`-h` |
| `completions/lilhomie.zsh` | zsh | subcommands with descriptions, per-command argument slots, global flags |
| `completions/lilhomie.fish` | fish | subcommands with descriptions, global flags, brightness level suggestions for `set` |

### Quick install

**zsh**
```bash
sudo -S -p '' cp completions/lilhomie.zsh /usr/local/share/zsh/site-functions/_lilhomie
```

**bash**
```bash
sudo -S -p '' cp completions/lilhomie.bash /etc/bash_completion.d/lilhomie
```

**fish**
```bash
cp completions/lilhomie.fish ~/.config/fish/completions/lilhomie.fish
```

---

## Files changed

- `lilhomie-cli/main.swift` — `--json` flag support in all commands
- `completions/lilhomie.bash` — new bash completion script
- `completions/lilhomie.zsh` — new zsh completion script
- `completions/lilhomie.fish` — new fish completion script
- `README.md` — documented `--json` flag with examples, added shell completion install section